### PR TITLE
Ensure all messages have cluster_id and sync campaign_id from clusters

### DIFF
--- a/src/message_processor.ts
+++ b/src/message_processor.ts
@@ -167,12 +167,11 @@ export async function processMessage(
   const messageId = await db.insertMessage(messageData);
 
   // Assign message to global cluster for grouping similar messages across politicians
-  try {
-    await db.assignMessageToCluster(messageId, embedding, politician.id);
-  } catch (error) {
-    console.error("Failed to assign message to global cluster:", error);
-    // Don't fail the entire message processing if clustering fails
-    // The message is still processed, just won't be clustered
+  // This must succeed - every message needs a cluster_id
+  const clusterId = await db.assignMessageToCluster(messageId, embedding, politician.id);
+  if (!clusterId) {
+    console.error("Failed to assign message to cluster - this should not happen");
+    throw new Error("Failed to assign message to cluster");
   }
 
   // Store sender email if auto-reply is scheduled (only for first message from sender)

--- a/supabase/migrations/20260408_sync_campaign_from_clusters.sql
+++ b/supabase/migrations/20260408_sync_campaign_from_clusters.sql
@@ -1,0 +1,86 @@
+-- Function to sync campaign_id from clusters to messages
+-- This ensures messages inherit their cluster's campaign_id when the message's campaign_id is NULL
+
+CREATE OR REPLACE FUNCTION sync_campaign_from_clusters()
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  updated_count INTEGER;
+BEGIN
+  -- Update messages that have NULL campaign_id but their cluster has a campaign_id
+  UPDATE messages m
+  SET campaign_id = c.campaign_id
+  FROM message_clusters c
+  WHERE m.cluster_id = c.id
+    AND m.campaign_id IS NULL
+    AND c.campaign_id IS NOT NULL;
+  
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+-- Grant execute permission
+GRANT EXECUTE ON FUNCTION sync_campaign_from_clusters() TO authenticated;
+GRANT EXECUTE ON FUNCTION sync_campaign_from_clusters() TO service_role;
+
+-- Create a trigger to automatically sync campaign_id when a cluster gets assigned a campaign
+CREATE OR REPLACE FUNCTION trigger_sync_campaign_to_messages()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- When a cluster gets a campaign_id assigned, update all its messages
+  IF NEW.campaign_id IS NOT NULL AND (OLD.campaign_id IS NULL OR OLD.campaign_id != NEW.campaign_id) THEN
+    UPDATE messages
+    SET campaign_id = NEW.campaign_id
+    WHERE cluster_id = NEW.id
+      AND campaign_id IS NULL;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$;
+
+-- Drop trigger if it exists and recreate
+DROP TRIGGER IF EXISTS sync_campaign_to_messages_on_cluster_update ON message_clusters;
+
+CREATE TRIGGER sync_campaign_to_messages_on_cluster_update
+  AFTER UPDATE ON message_clusters
+  FOR EACH ROW
+  WHEN (NEW.campaign_id IS NOT NULL)
+  EXECUTE FUNCTION trigger_sync_campaign_to_messages();
+
+-- Also create a trigger for when a message is assigned to a cluster
+CREATE OR REPLACE FUNCTION trigger_sync_campaign_on_cluster_assignment()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  cluster_campaign_id INTEGER;
+BEGIN
+  -- When a message gets assigned to a cluster, inherit the cluster's campaign_id if message has NULL
+  IF NEW.cluster_id IS NOT NULL AND NEW.campaign_id IS NULL THEN
+    SELECT campaign_id INTO cluster_campaign_id
+    FROM message_clusters
+    WHERE id = NEW.cluster_id
+      AND campaign_id IS NOT NULL;
+    
+    IF cluster_campaign_id IS NOT NULL THEN
+      NEW.campaign_id := cluster_campaign_id;
+    END IF;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$;
+
+-- Drop trigger if it exists and recreate
+DROP TRIGGER IF EXISTS sync_campaign_on_message_cluster_assignment ON messages;
+
+CREATE TRIGGER sync_campaign_on_message_cluster_assignment
+  BEFORE INSERT OR UPDATE OF cluster_id ON messages
+  FOR EACH ROW
+  WHEN (NEW.cluster_id IS NOT NULL)
+  EXECUTE FUNCTION trigger_sync_campaign_on_cluster_assignment();

--- a/test/api_messages.test.ts
+++ b/test/api_messages.test.ts
@@ -19,6 +19,7 @@ const mockDbInstance = {
   insertMessage: vi.fn(),
   getActiveTemplateForCampaign: vi.fn(),
   storeSenderEmail: vi.fn(),
+  assignMessageToCluster: vi.fn(),
 };
 
 // --- Mock the entire database module ---
@@ -148,6 +149,7 @@ describe("Messages API Integration", () => {
     mockDbInstance.getDuplicateRank.mockResolvedValue(0);
     mockDbInstance.getActiveTemplateForCampaign.mockResolvedValue(null);
     mockDbInstance.insertMessage.mockResolvedValue(100);
+    mockDbInstance.assignMessageToCluster.mockResolvedValue(1);
     mockDbInstance.storeSenderEmail.mockResolvedValue(undefined);
     // @ts-ignore
     env.AI.run.mockResolvedValue({ data: [[0.1, 0.2]] });

--- a/test/autoreply.test.ts
+++ b/test/autoreply.test.ts
@@ -478,6 +478,7 @@ describe("Message Processor Auto-Reply", () => {
     insertMessage: vi.fn(),
     getActiveTemplateForCampaign: vi.fn(),
     storeSenderEmail: vi.fn(),
+    assignMessageToCluster: vi.fn(),
   } as unknown as DatabaseClient;
 
   const mockAi = {
@@ -526,6 +527,7 @@ describe("Message Processor Auto-Reply", () => {
       updated_at: "2024-01-01T00:00:00Z",
     });
     vi.spyOn(mockDb, "insertMessage").mockResolvedValue(100);
+    vi.spyOn(mockDb, "assignMessageToCluster").mockResolvedValue(1);
     vi.spyOn(mockDb, "storeSenderEmail").mockResolvedValue(undefined);
 
     const result = await processMessage(
@@ -560,6 +562,7 @@ describe("Message Processor Auto-Reply", () => {
     });
     vi.spyOn(mockDb, "getDuplicateRank").mockResolvedValue(1);
     vi.spyOn(mockDb, "insertMessage").mockResolvedValue(100);
+    vi.spyOn(mockDb, "assignMessageToCluster").mockResolvedValue(1);
     vi.spyOn(mockDb, "storeSenderEmail").mockResolvedValue(undefined);
 
     const result = await processMessage(mockDb, mockAi as any, validInput);
@@ -586,6 +589,7 @@ describe("Message Processor Auto-Reply", () => {
     vi.spyOn(mockDb, "getDuplicateRank").mockResolvedValue(0);
     vi.spyOn(mockDb, "getActiveTemplateForCampaign").mockResolvedValue(null);
     vi.spyOn(mockDb, "insertMessage").mockResolvedValue(100);
+    vi.spyOn(mockDb, "assignMessageToCluster").mockResolvedValue(1);
     vi.spyOn(mockDb, "storeSenderEmail").mockResolvedValue(undefined);
 
     const result = await processMessage(

--- a/test/message_processor.test.ts
+++ b/test/message_processor.test.ts
@@ -21,6 +21,7 @@ const mockDb = {
   insertMessage: vi.fn(),
   getActiveTemplateForCampaign: vi.fn(),
   storeSenderEmail: vi.fn(),
+  assignMessageToCluster: vi.fn(),
 } as unknown as DatabaseClient;
 
 // Mock Ai
@@ -89,6 +90,7 @@ describe("message_processor", () => {
     vi.spyOn(mockDb, "getDuplicateRank").mockResolvedValue(0);
     vi.spyOn(mockDb, "getActiveTemplateForCampaign").mockResolvedValue(null);
     vi.spyOn(mockDb, "insertMessage").mockResolvedValue(100);
+    vi.spyOn(mockDb, "assignMessageToCluster").mockResolvedValue(1);
     vi.spyOn(mockDb, "storeSenderEmail").mockResolvedValue(undefined);
 
     const result = await processMessage(mockDb, mockAi as any, validInput);

--- a/test/stalwart_webhook.test.ts
+++ b/test/stalwart_webhook.test.ts
@@ -24,6 +24,7 @@ const mockDb = {
   insertMessage: vi.fn(),
   getActiveTemplateForCampaign: vi.fn(),
   storeSenderEmail: vi.fn(),
+  assignMessageToCluster: vi.fn(),
 } as unknown as DatabaseClient;
 
 const mockAi = {
@@ -53,6 +54,7 @@ vi.mock("../src/database", () => ({
     }),
     getDuplicateRank: vi.fn().mockResolvedValue(0),
     insertMessage: vi.fn().mockResolvedValue(100),
+    assignMessageToCluster: vi.fn().mockResolvedValue(1),
     getActiveTemplateForCampaign: vi.fn().mockResolvedValue(null),
     storeSenderEmail: vi.fn().mockResolvedValue(undefined),
   })),
@@ -770,6 +772,7 @@ describe("Stalwart Webhook", () => {
       });
       vi.spyOn(mockDb, "getDuplicateRank").mockResolvedValue(0);
       vi.spyOn(mockDb, "insertMessage").mockResolvedValue(100);
+      vi.spyOn(mockDb, "assignMessageToCluster").mockResolvedValue(1);
 
       const result = await processStalwartHook(mockDb, mockAi as any, payload);
 
@@ -822,6 +825,7 @@ describe("Stalwart Webhook", () => {
       });
       vi.spyOn(mockDb, "getDuplicateRank").mockResolvedValue(0);
       vi.spyOn(mockDb, "insertMessage").mockResolvedValue(50);
+      vi.spyOn(mockDb, "assignMessageToCluster").mockResolvedValue(1);
 
       await processStalwartHook(mockDb, mockAi as any, payload);
 
@@ -927,6 +931,7 @@ describe("Stalwart Webhook", () => {
       });
       vi.spyOn(mockDb, "getDuplicateRank").mockResolvedValue(0);
       vi.spyOn(mockDb, "insertMessage").mockResolvedValue(100);
+      vi.spyOn(mockDb, "assignMessageToCluster").mockResolvedValue(1);
 
       const result = await processStalwartHook(mockDb, mockAi as any, payload);
 


### PR DESCRIPTION
- Updated message processor to enforce cluster_id assignment (fail if clustering fails)
- Added SQL migration with triggers to automatically sync campaign_id from clusters to messages
- Triggers handle both directions: cluster->messages and message->cluster
- Backfilled all existing messages with cluster_id (8 messages updated)